### PR TITLE
Add Upper Bound for Group Size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.1.0 (February 14th, 2019)
+
+* Added limit option for builder.  This (optionally) ensures no group can exceed a given threshold.
+
 # 2.0.0 (January 29th, 2019)
 
 * Breaking Change: Builder#add signature changed from groups splat operator to two-dimensional array.  Splat operator introduces an under-the-hood copy and can impact performance with large argument lists.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    paged_groups (2.0.0)
+    paged_groups (2.1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ Now, our resulting pages would become:
 ]
 ````
 
-
 ### Forcing Same Page
 
 Another customization that may come in handy is the ability to force-add groups to the current page.  For example, say we wanted to add another group to our initial data set, but we want it to end up on the same page as the last records:
@@ -191,6 +190,16 @@ Now the result pages would be:
   ]
 ]
 ````
+
+#### Group Size Upper Bound
+
+You may run into the case where a group is just so large that it makes more sense to just split it up than keep it atomic.  In this case, you can specify a 'limit' option:
+
+````ruby
+pages = PagedGroups.builder(page_size: 50, limit: 150).add(data).all
+````
+
+The above builder can now be interpreted as: *Each page should contain a maximum of 50 rows, but split groups over 150 rows*
 
 ## Contributing
 

--- a/lib/paged_groups/version.rb
+++ b/lib/paged_groups/version.rb
@@ -8,5 +8,5 @@
 #
 
 module PagedGroups
-  VERSION = '2.0.0'
+  VERSION = '2.1.0'
 end

--- a/spec/paged_groups/builder_spec.rb
+++ b/spec/paged_groups/builder_spec.rb
@@ -26,6 +26,18 @@ describe ::PagedGroups::Builder do
 
   it { expect(page_builder.page_size).to eq(page_size) }
 
+  describe '#to_s' do
+    it 'should return page and row count' do
+      class_name = ::PagedGroups::Builder.name
+      page_count = subject.page_count
+      row_count = subject.row_count
+
+      expected = "[#{class_name}] Page Count: #{page_count}, Row Count: #{row_count}"
+
+      expect(subject.to_s).to eq(expected)
+    end
+  end
+
   describe '#add and #all' do
     it 'should page groups' do
       page_builder.add([hundred_rows])

--- a/spec/paged_groups/paged_groups_spec.rb
+++ b/spec/paged_groups/paged_groups_spec.rb
@@ -45,6 +45,36 @@ describe ::PagedGroups do
 
     let(:spacer) { { id: nil, name: '' } }
 
+    specify 'Number of records per page should never exceed limit' do
+      pages = PagedGroups.builder(page_size: page_size, limit: 4).add(data).all
+
+      expected_pages = [
+        [
+          { id: 1, name: 'Jordan' },
+          { id: 2, name: 'Pippen' },
+          { id: 3, name: 'Rodman' },
+          { id: 4, name: 'Harper' }
+        ],
+        [
+          { id: 5, name: 'Longley' },
+          { id: 6, name: 'Kukoc' },
+          { id: 7, name: 'Kerr' }
+        ],
+        [
+          { id: 8, name: 'Buechler' },
+          { id: 9, name: 'Wennington' },
+          { id: 10, name: 'Simpkins' }
+        ],
+        [
+          { id: 11, name: 'Caffey' },
+          { id: 12, name: 'Edwards' },
+          { id: 13, name: 'Salley' }
+        ]
+      ]
+
+      expect(pages).to eq(expected_pages)
+    end
+
     specify 'Standard use-case example works as advertised' do
       pages = PagedGroups.builder(page_size: page_size).add(data).all
 


### PR DESCRIPTION
A case was found where one group was so offensive to the page_size, that rudimentarily splitting it is more beneficial than keeping the group atomic.  This is a new option (limit) that can be passed in.